### PR TITLE
Scan conversion done right

### DIFF
--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -189,25 +189,25 @@ Camera::clipScreen2D(const Triangle2D &tri_img) const{
   std::vector<Triangle2D> triangles{tri_img};
   // Clip on Left edge
   Vector2d left_edge_normal(1,0);
-  Vector2d pt_on_left_edge(-2,0);
+  Vector2d pt_on_left_edge(0,0);
   auto tris_after_left_clip = clip2DEdge(left_edge_normal,
                                          pt_on_left_edge,
                                          triangles);
   // Clip on Right edge
   Vector2d right_edge_normal(-1,0);
-  Vector2d pt_on_right_edge(screen_width_+1,0);
+  Vector2d pt_on_right_edge(screen_width_,0);
   auto tris_after_right_clip = clip2DEdge(right_edge_normal,
                                           pt_on_right_edge,
                                           tris_after_left_clip);
   // Clip on Top edge
   Vector2d top_edge_normal(0,1);
-  Vector2d pt_on_top_edge(0,-1);
+  Vector2d pt_on_top_edge(0,0);
   auto tris_after_top_clip = clip2DEdge(top_edge_normal,
                                         pt_on_top_edge,
                                         tris_after_right_clip);
   // Clip on Bottom edge
   Vector2d bottom_edge_normal(0,-1);
-  Vector2d pt_on_bottom_edge(0,screen_height_+1);
+  Vector2d pt_on_bottom_edge(0,screen_height_);
   auto tris_after_bottom_clip = clip2DEdge(bottom_edge_normal,
                                            pt_on_bottom_edge,
                                            tris_after_top_clip);

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -189,25 +189,25 @@ Camera::clipScreen2D(const Triangle2D &tri_img) const{
   std::vector<Triangle2D> triangles{tri_img};
   // Clip on Left edge
   Vector2d left_edge_normal(1,0);
-  Vector2d pt_on_left_edge(0,0);
+  Vector2d pt_on_left_edge(-2,0);
   auto tris_after_left_clip = clip2DEdge(left_edge_normal,
                                          pt_on_left_edge,
                                          triangles);
   // Clip on Right edge
   Vector2d right_edge_normal(-1,0);
-  Vector2d pt_on_right_edge(screen_width_-1,0);
+  Vector2d pt_on_right_edge(screen_width_+1,0);
   auto tris_after_right_clip = clip2DEdge(right_edge_normal,
                                           pt_on_right_edge,
                                           tris_after_left_clip);
   // Clip on Top edge
   Vector2d top_edge_normal(0,1);
-  Vector2d pt_on_top_edge(0,0);
+  Vector2d pt_on_top_edge(0,-1);
   auto tris_after_top_clip = clip2DEdge(top_edge_normal,
                                         pt_on_top_edge,
                                         tris_after_right_clip);
   // Clip on Bottom edge
   Vector2d bottom_edge_normal(0,-1);
-  Vector2d pt_on_bottom_edge(0,screen_height_-1);
+  Vector2d pt_on_bottom_edge(0,screen_height_+1);
   auto tris_after_bottom_clip = clip2DEdge(bottom_edge_normal,
                                            pt_on_bottom_edge,
                                            tris_after_top_clip);

--- a/src/Playground.cpp
+++ b/src/Playground.cpp
@@ -169,10 +169,6 @@ class CameraApplication: public olc::PixelGameEngine{
       std::swap(p3y,p2y);
       std::swap(tx3,tx2);}
 
-//    DrawCircle(p1x,p1y,2,olc::DARK_BLUE);
-//    DrawCircle(p2x,p2y,2,olc::DARK_GREEN);
-//    DrawCircle(p3x,p3y,2,olc::DARK_RED);
-
     int y12 = p2y-p1y; assert(y12>=0);
     int x12 = p2x-p1x;
     int y13 = p3y-p1y; assert(y13>=0);

--- a/src/Playground.cpp
+++ b/src/Playground.cpp
@@ -34,9 +34,9 @@ class CameraApplication: public olc::PixelGameEngine{
 //    mesh = *spyro;
 //    auto teddy= cg::loadOBJ("/home/shooshan/Pictures/teddy.obj", false);
 //    mesh = *teddy;
-//    auto teapot = cg::loadOBJ("/home/shooshan/Pictures/teapot.obj", false);
-//    mesh = *teapot;
-      mesh = *cg::cube();
+    auto teapot = cg::loadOBJ("/home/shooshan/Pictures/teapot.obj", false);
+    mesh = *teapot;
+//      mesh = *cg::cube();
 //    cg::Triangle triangle{
 //      Vector3d(0,-1,-10),Vector3d(-1,-1,-10),Vector3d(0,1,-10),
 //      Vector2d(0,1),Vector2d(1,1),Vector2d(0,0)};

--- a/src/Playground.cpp
+++ b/src/Playground.cpp
@@ -65,7 +65,7 @@ class CameraApplication: public olc::PixelGameEngine{
     Clear(olc::DARK_GREY);
     // reset depth buffer
     for(auto &row:depth_buffer)
-      row.assign(ScreenWidth(), -1e9);
+      row.assign(ScreenWidth()+1, -1e9);
 
     // Modify mesh's world position
     double z_rot = 0.0001/fElapsedTime;
@@ -77,8 +77,8 @@ class CameraApplication: public olc::PixelGameEngine{
     auto rotz_mat = cg::rotateZ(z_rot);
     mesh.pose.position = cg::translation(0,0,-20).rightCols<1>();
     //mesh.pose.orientation = rotx_mat*roty_mat*rotz_mat*mesh.pose.orientation;
-    Eigen::Matrix4d tf = mesh.pose.matrix();
-    //Eigen::Matrix4d tf = Eigen::Matrix4d::Identity();
+    //Eigen::Matrix4d tf = mesh.pose.matrix();
+    Eigen::Matrix4d tf = Eigen::Matrix4d::Identity();
 
     // Handle keyboard input
     handleCameraMotion(fElapsedTime);
@@ -194,16 +194,16 @@ class CameraApplication: public olc::PixelGameEngine{
     double w12 = tx2.z() - tx1.z();
     double w13 = tx3.z() - tx1.z();
 
-    if(flat_top && flat_bottom){
-      // Triangle points are on a single line
-      int min_x = std::min(std::min(p1x,p2x),p3x);
-      int max_x = std::max(std::max(p1x,p2x),p3x);
-
-      for(int dx=0; min_x+dx<=max_x; ++dx){
-        // TODO: Consider texture
-        Draw(min_x+dx,p1y,olc::WHITE);
-      }
-    }
+//    if(flat_top && flat_bottom){
+//      // Triangle points are on a single line
+//      int min_x = std::min(std::min(p1x,p2x),p3x);
+//      int max_x = std::max(std::max(p1x,p2x),p3x);
+//
+//      for(int dx=0; min_x+dx<=max_x; ++dx){
+//        // TODO: Consider texture
+//        Draw(min_x+dx,p1y,olc::WHITE);
+//      }
+//    }
 
     // _d as reminder that it's double
     double sx_d = p1x;
@@ -248,7 +248,12 @@ class CameraApplication: public olc::PixelGameEngine{
 
         int screen_x = sx + dx;
         int screen_y = p1y + dy;
-        Draw(screen_x, screen_y, px_color);
+        if(screen_x>ScreenWidth()||screen_x<0)continue;
+        if(screen_y>ScreenHeight()||screen_y<0)continue;
+        if(interp_texel_w > depth_buffer[screen_y][screen_x]){
+          Draw(screen_x, screen_y, px_color);
+          depth_buffer[screen_y][screen_x] = interp_texel_w;
+        }
       }
       // Increment start and end x values
       sx_d += dx12;
@@ -304,7 +309,12 @@ class CameraApplication: public olc::PixelGameEngine{
 
         int screen_x = sx + dx;
         int screen_y = p2y + dy;
-        Draw(screen_x, screen_y, px_color);
+        if(screen_x>ScreenWidth()||screen_x<0)continue;
+        if(screen_y>ScreenHeight()||screen_y<0)continue;
+        if(interp_texel_w > depth_buffer[screen_y][screen_x]){
+          Draw(screen_x, screen_y, px_color);
+          depth_buffer[screen_y][screen_x] = interp_texel_w;
+        }
       }
       // Increment start and end x values
       sx_d += dx23;

--- a/src/Playground.cpp
+++ b/src/Playground.cpp
@@ -212,7 +212,7 @@ class CameraApplication: public olc::PixelGameEngine{
 
 int main(){
   CameraApplication app;
-  if(!app.Construct(1920, 1080, 1, 1)) return 0;
+  if(!app.Construct(640, 480, 10, 10)) return 0;
   app.Start();
   return 0;
 }

--- a/src/Playground.cpp
+++ b/src/Playground.cpp
@@ -34,13 +34,23 @@ class CameraApplication: public olc::PixelGameEngine{
 //    mesh = *spyro;
 //    auto teddy= cg::loadOBJ("/home/shooshan/Pictures/teddy.obj", false);
 //    mesh = *teddy;
-    auto teapot = cg::loadOBJ("/home/shooshan/Pictures/teapot.obj", false);
-    mesh = *teapot;
+//    auto teapot = cg::loadOBJ("/home/shooshan/Pictures/teapot.obj", false);
+//    mesh = *teapot;
       //mesh = *cg::cube();
 //    cg::Triangle triangle{
 //      Vector3d(0,-1,-10),Vector3d(-1,-1,-10),Vector3d(0,1,-10),
 //      Vector2d(0,1),Vector2d(1,1),Vector2d(0,0)};
 //    mesh.tris.push_back(triangle);
+
+// 2 Thin triangles
+cg::Triangle thin_bottom{
+  Vector3d(0,0,-10),Vector3d(-10,0,-10),Vector3d(-10,0.5,-10)
+};
+mesh.tris.push_back(thin_bottom);
+//    cg::Triangle thin_top{
+//        Vector3d(0,0,-10),Vector3d(-10,0.5,-10),Vector3d(0,0.5,-10)
+//    };
+//    mesh.tris.push_back(thin_top);
 //    auto axis = cg::loadOBJ("/home/shooshan/Pictures/axis.obj", false);
 //    mesh = *axis;
 
@@ -87,7 +97,7 @@ class CameraApplication: public olc::PixelGameEngine{
       for(const auto& screen_tri : triangles_to_draw){
         DrawTexturedTriangle(screen_tri, sprite);
 
-//        DrawTriangle(screen_tri.points[0].x(), screen_tri.points[0].y(),
+//        FillTriangle(screen_tri.points[0].x(), screen_tri.points[0].y(),
 //                     screen_tri.points[1].x(), screen_tri.points[1].y(),
 //                     screen_tri.points[2].x(), screen_tri.points[2].y());
       }
@@ -148,15 +158,19 @@ class CameraApplication: public olc::PixelGameEngine{
       std::swap(pt3,pt2);
       std::swap(tx3,tx2);}
 
+//    DrawCircle(pt1.x(),pt1.y(),2,olc::DARK_BLUE);
+//    DrawCircle(pt2.x(),pt2.y(),2,olc::DARK_GREEN);
+//    DrawCircle(pt3.x(),pt3.y(),2,olc::DARK_RED);
+
     double y12 = pt2.y() - pt1.y();
     double x12 = pt2.x() - pt1.x();
     double y13 = pt3.y() - pt1.y();
     double x13 = pt3.x() - pt1.x();
     double dx12 = 0;
-    if(pt2.y()-pt1.y()>-cg::EPS)
+    if(fabs(pt2.y()-pt1.y())>cg::EPS)
       dx12=x12/y12;
     double dx13 = 0;
-    if(pt3.y()-pt1.y()>-cg::EPS)
+    if(fabs(pt3.y()-pt1.y())>cg::EPS)
       dx13=x13/y13;
 
     // _d as reminder that it's double
@@ -165,42 +179,43 @@ class CameraApplication: public olc::PixelGameEngine{
 
     // Scan horizontal lines from top to bottom of triangle
     // This is for the top "half" of the triangle
-    for(int dy=0; pt1.y()+dy<pt2.y(); ++dy){
+    for(int dy=0; pt1.y()+dy<=pt2.y()+cg::EPS; ++dy){
       // Select actual pixel indices using the double type values
-      int sx = std::floor(sx_d);
-      int ex = std::floor(ex_d);
+      int sx = std::round(sx_d);
+      int ex = std::round(ex_d);
       if(ex < sx){std::swap(sx,ex);}
 
       for(int dx=0; sx+dx <= ex; ++dx){
         // Draw the pixel value from texture in the screen xy position
         int screen_x = sx + dx;
-        int screen_y = (int)pt1.y() + dy;
+        int screen_y = std::round(pt1.y()) + dy;
         Draw(screen_x, screen_y, olc::WHITE);
       }
       // Increment start and end x values
       sx_d += dx12;
-      ex_d += dx13;
+
+      if(pt1.y()+dy+1 > pt2.y()) ex_d += dx13*(pt2.y()-(pt1.y()+dy));
+      else ex_d += dx13;
     }
 
     double y23 = pt3.y()-pt2.y();
     double x23 = pt3.x()-pt2.x();
     double dx23 = 0;
-    if(pt3.y()-pt2.y()>-cg::EPS)
+    if(fabs(pt3.y()-pt2.y())>cg::EPS)
       dx23=x23/y23;
 
-    ex_d -= dx13;
     sx_d = pt2.x();
 
-    for(int dy=0; pt2.y()+dy<pt3.y(); ++dy){
+    for(int dy=0; pt2.y()+dy<=pt3.y()+cg::EPS; ++dy){
       // Select actual pixel indices using the double type values
-      int sx = std::floor(sx_d);
-      int ex = std::floor(ex_d);
+      int sx = std::round(sx_d);
+      int ex = std::round(ex_d);
       if(ex < sx){std::swap(sx,ex);}
 
       for(int dx=0; sx+dx <= ex; ++dx){
         // Draw the pixel value from texture in the screen xy position
         int screen_x = sx + dx;
-        int screen_y = (int)pt2.y() + dy;
+        int screen_y = std::round(pt2.y()) + dy;
         Draw(screen_x, screen_y, olc::WHITE);
       }
       // Increment start and end x values


### PR DESCRIPTION
Reimplement scan conversion, considering floating point inaccuracy
![teapot_complete](https://user-images.githubusercontent.com/7596063/103402829-ea2dc380-4b1b-11eb-82c9-d6d9d94d976a.png)


No more cracks/ unfilled pixels between polygons.
Texturing and depth buffer working as well.