### PR TITLE
Flat shade option

### DIFF
--- a/src/Playground.cpp
+++ b/src/Playground.cpp
@@ -23,6 +23,10 @@ class CameraApplication: public olc::PixelGameEngine{
 
     lights.emplace("dir_light",
                    std::make_shared<cg::DirectionLight>(Vector3d(1,-1,1)));
+    Vector3d light_brightness(1.7,1.7,1.7);
+    lights.at("dir_light")->La = light_brightness;
+    lights.at("dir_light")->Ld = light_brightness;
+    lights.at("dir_light")->Ls = light_brightness;
 
     renderer = std::make_unique<cg::Renderer>(this);
 

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -15,7 +15,7 @@ Renderer::Renderer(olc::PixelGameEngine* p_pge){
 }
 
 void Renderer::clear(){
-  pge->Clear(olc::DARK_GREY);
+  pge->Clear(olc::CYAN);
 
   // reset depth buffer
   for(auto &row:depth_buffer)

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -352,18 +352,16 @@ Vector3d Renderer::shade(
 
   double n_dot_l = surface_normal.dot(point_to_light);
 
-  Vector3d ambiance = material_ambience.cwiseProduct(light_ambience);
-  Vector3d diffuse = material_diffuse.cwiseProduct(light_diffuse)
-      * std::max(n_dot_l, 0.0);
-  Vector3d amb_dif_emit = ambiance+diffuse+material_emittance;
-  Vector3d with_texture = amb_dif_emit.cwiseProduct(color_from_texture);
-  Vector3d I_rgb = with_texture;
+  Vector3d I_rgb =
+      ((material_ambience.cwiseProduct(light_ambience))
+      +(material_diffuse.cwiseProduct(light_diffuse)
+      * std::max(n_dot_l, 0.0))+material_emittance)
+      .cwiseProduct(color_from_texture);
 
   // Shouldn't have specular reflection if light is behind surface right??
   if(n_dot_l > 0){
-    Vector3d spec = material_specular.cwiseProduct(light_specular)
-    * pow(surface_normal.dot(cam_2_light_halfway),glossiness_exponent);
-    I_rgb += spec;
+    I_rgb += material_specular.cwiseProduct(light_specular)
+        * pow(surface_normal.dot(cam_2_light_halfway),glossiness_exponent);
   }
 
   // Clip rgb to max 1.0

--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -455,6 +455,11 @@ Vector3d slerp(const Vector3d &from, const Vector3d &to, double s){
   return alpha*from+beta*to;
 }
 
+Vector3d nlerp(const Vector3d &from, const Vector3d &to, double s){
+  auto nlerped = (1-s)*from + s*to;
+  return nlerped.normalized();
+}
+
 std::vector<Mesh_ptr> tinyOBJLoad(const std::string& obj_path,
                                   const std::string& mtl_search_path){
   tinyobj::ObjReaderConfig reader_config;

--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -456,8 +456,9 @@ Vector3d slerp(const Vector3d &from, const Vector3d &to, double s){
 }
 
 Vector3d nlerp(const Vector3d &from, const Vector3d &to, double s){
-  auto nlerped = (1-s)*from + s*to;
-  return nlerped.normalized();
+  Vector3d nlerped = (1-s)*from + s*to;
+  nlerped.normalize();
+  return nlerped;
 }
 
 std::vector<Mesh_ptr> tinyOBJLoad(const std::string& obj_path,

--- a/src/include/Camera.h
+++ b/src/include/Camera.h
@@ -9,6 +9,7 @@
 
 #include "Point2d.h"
 #include "Mesh.h"
+#include "type.h"
 
 using Eigen::Matrix4d;
 using Eigen::Vector4d;
@@ -142,11 +143,14 @@ class Camera{
   // Rotate camera to right by theta in radians
   void yawRight(double theta_radians);
 
+  void setShadeMethod(Shade shade_method);
+
   Pose pose_world;
  private:
   // Distance is in units of the world
   double ar_, vertical_fov_, near_plane_dist_, far_plane_dist_;
   int screen_width_, screen_height_;
+  Shade shade_method_;
 
   // Projection matrix
   Matrix4d projection_mat_;

--- a/src/include/Renderer.h
+++ b/src/include/Renderer.h
@@ -5,6 +5,7 @@
 #include "Mesh.h"
 #include "Camera.h"
 #include "Light.h"
+#include "type.h"
 
 namespace cg{
 
@@ -31,9 +32,16 @@ class Renderer : public olc::PGEX{
    * Renders the image viewed of a mesh from a camera
    * Depth buffer is only cleared with this->clear(), so repeated calls
    * with multiple meshes produce occlusion
+   *
+   * args:
+   * cam: The camera to view with
+   * mesh: The mesh to draw
+   * lights: lights in the scene
+   * shading_method: cg::FLAT, cg::BLINN_PHONG
    */
   void draw(const Camera_ptr &cam, const Mesh_ptr &mesh,
-            const std::unordered_map<std::string, Light_ptr> &lights);
+            const std::unordered_map<std::string, Light_ptr> &lights,
+            Shade shading_method=FLAT);
 
   void shadeAndDrawTriangle(
       const Triangle& triangle,
@@ -96,6 +104,7 @@ class Renderer : public olc::PGEX{
 
  private:
   std::vector<std::vector<double>> depth_buffer;
+  Shade shading_method_=FLAT;
 };
 
 } //namespace cg

--- a/src/include/Utility.h
+++ b/src/include/Utility.h
@@ -106,4 +106,10 @@ std::shared_ptr<Vector2d> lineLineIntersect2d(
  * when s==1, result is 'to'
  */
 Vector3d slerp(const Vector3d &from, const Vector3d &to, double s);
+
+/*
+ * normalized linear interpolation produces exact same result as slerp when
+ * s=0.5 and is faster.
+ */
+Vector3d nlerp(const Vector3d &from, const Vector3d &to, double s);
 } // namespace cg

--- a/src/include/type.h
+++ b/src/include/type.h
@@ -6,4 +6,10 @@
 #include "Line2d.h"
 
 namespace cg{
+
+enum Shade{
+  FLAT,
+  BLINN_PHONG
+};
+
 } // namespace cg


### PR DESCRIPTION
Introduce option for flat shading vs blinn phong,

Skip slerp when flat shading; use 0.5 nlerp for specular halfway*face normal

Optimize performance by reducing calls to eigen matrix constructor